### PR TITLE
Remove deprecated setting android.enableR8=true

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
-android.enableR8=true
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
Android Studio complains about this line during Gradle sync.

FYI There is a pull request for Flutter, also a Stack Overflow question:

https://github.com/flutter/flutter/pull/63339

https://stackoverflow.com/questions/60397617/progruard-and-r8-being-deprecated-android-studio-3-6
> If you have android.enableR8 = true in your gradle.properties, remove it as R8 it the default tooling and the android.enableR8 setting itself is deprecated, causing these deprecation warnings.
